### PR TITLE
CLI is error tolerant now.

### DIFF
--- a/src/seb/cli.py
+++ b/src/seb/cli.py
@@ -25,11 +25,16 @@ END = "\033[0m"
 def pretty_print(results: seb.BenchmarkResults, langs: list[str]):
     """Pretty prints benchmark results in a table along with the average."""
     sorted_tasks = sorted(results.task_results, key=lambda t: t.task_name)
-    task_names = [t.task_name for t in sorted_tasks]
-    scores = [get_main_score(t, langs) for t in sorted_tasks]  # type: ignore
     table = []
-    for task, score in zip(task_names, scores):
-        table.append([task, score])
+    scores = []
+    for task_or_error in sorted_tasks:
+        name = task_or_error.task_name
+        if isinstance(task_or_error, seb.TaskError):
+            score = "NA"
+        else:
+            score = get_main_score(task_or_error, langs)
+            scores.append(score)
+        table.append([name, score])
     # Adding empty line before average, so it is highlighted
     table.append(["", ""])
     mean_score = str(mean(scores))
@@ -53,7 +58,7 @@ def run_benchmark(model_name_or_path: str) -> seb.BenchmarkResults:
         loader=partial(SentenceTransformer, model_name_or_path=model_name_or_path),  # type: ignore
     )
     benchmark = seb.Benchmark()
-    res = benchmark.evaluate_model(model)
+    res = benchmark.evaluate_model(model, raise_errors=False)
     return res
 
 
@@ -76,6 +81,6 @@ def main():
     logging.info("Saving results...")
     save_path = Path(args.save_path)
     with save_path.open("w") as save_file:
-        save_file.write(results.model_dump_json())
+        save_file.write(results.model_dump_json())  # type: ignore
     print("Benchmark Results:")
     pretty_print(results, langs=["da", "no", "se"])

--- a/src/seb/cli.py
+++ b/src/seb/cli.py
@@ -10,19 +10,13 @@ from sentence_transformers import SentenceTransformer
 
 import seb
 
-
-def get_main_score(task: seb.TaskResult, langs: list[str]) -> float:
-    _langs = set(langs) & set(task.languages)
-    return task.get_main_score(_langs) * 100
-
-
 BOLD = "\033[1m"
 UNDERLINE = "\033[4m"
 ITALIC = "\x1B[3m"
 END = "\033[0m"
 
 
-def pretty_print(results: seb.BenchmarkResults, langs: list[str]):
+def pretty_print(results: seb.BenchmarkResults):
     """Pretty prints benchmark results in a table along with the average."""
     sorted_tasks = sorted(results.task_results, key=lambda t: t.task_name)
     table = []
@@ -32,7 +26,7 @@ def pretty_print(results: seb.BenchmarkResults, langs: list[str]):
         if isinstance(task_or_error, seb.TaskError):
             score = "NA"
         else:
-            score = get_main_score(task_or_error, langs)
+            score = task_or_error.get_main_score()
             scores.append(score)
         table.append([name, score])
     # Adding empty line before average, so it is highlighted
@@ -82,5 +76,5 @@ def main():
     save_path = Path(args.save_path)
     with save_path.open("w") as save_file:
         save_file.write(results.model_dump_json())  # type: ignore
-    print("Benchmark Results:")
-    pretty_print(results, langs=["da", "no", "se"])
+    print("\n")
+    pretty_print(results)


### PR DESCRIPTION
By default the CLI will throw an error if one of the datasets is not available. Since DKHate needs authorization this is problematic behaviour for most users. The CLI will now tolerate errors and will print _NA_ for all tasks where results were unobtainable.